### PR TITLE
change color get query to avoid staticerror

### DIFF
--- a/lib/ReactGoogleMapImage.js
+++ b/lib/ReactGoogleMapImage.js
@@ -32,7 +32,7 @@ var GoogleMapImage = (function (_Component) {
         value: function getSrcParams() {
             var params = '';
             var counter = 0;
-            var defaultMarker = '&markers=blue|';
+            var defaultMarker = '&markers=color:blue|';
 
             for (var key in this.props.config) {
                 params += counter > 0 ? "&" : "";


### PR DESCRIPTION
From the example page, this is the query ur: https://maps.googleapis.com/maps/api/staticmap?center=32%20wulemotu%20ajoke%20street%20akoka&size=500x240&zoom=15&key=AIzaSyAmwA8tw1ZXG8fo16T3ymx2HY3Q1gw6dwU&mapType=roadmap&markers=blue|32%20wulemotu%20ajoke%20street%20akoka

![image](https://user-images.githubusercontent.com/41749920/194467206-17788711-ad2f-4188-90a9-57c68a7ed04b.png)

When we change from blue to color:blue, the error goes away:

https://maps.googleapis.com/maps/api/staticmap?center=32%20wulemotu%20ajoke%20street%20akoka&size=500x240&zoom=15&key=AIzaSyAmwA8tw1ZXG8fo16T3ymx2HY3Q1gw6dwU&mapType=roadmap&markers=color:blue|32%20wulemotu%20ajoke%20street%20akoka

![image](https://user-images.githubusercontent.com/41749920/194467305-511df4d4-22a9-49df-ba6a-a5f28e27807b.png)

